### PR TITLE
Removed setting userInteractionEnabled on swiperNoSwiping setter

### DIFF
--- a/Pod/Classes/URBNSwipeableController.m
+++ b/Pod/Classes/URBNSwipeableController.m
@@ -171,10 +171,7 @@ static NSString * const kSwiperControllerCloseAllKey = @"kSwiperControllerCloseA
 
 - (void)setSwiperNoSwiping:(BOOL)swiperNoSwiping {
     _swiperNoSwiping = swiperNoSwiping;
-    
-    // Need to still be able to detect touches on subviews of the scrollView, but do not allowing scrolling
     self.scrollView.scrollEnabled = !swiperNoSwiping;
-    self.scrollView.userInteractionEnabled = swiperNoSwiping;
 }
 
 #pragma mark - UIScrollViewDelegate

--- a/URBNSwipeableController.podspec
+++ b/URBNSwipeableController.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'URBNSwipeableController'
-  s.version          = '0.2.3'
+  s.version          = '0.2.4'
   s.summary          = 'URBNSwipeableController allows you to add swiping to any tableviewcell, collectionviewcell, or any old view.'
   s.homepage         = 'https://github.com/urbn/URBNDataSource'
   s.license          = 'MIT'


### PR DESCRIPTION
- We do not need to set userInteractionEnabled when setting the swiperNoSwiping property. This was not caught initially as I was passing YES, but in the cart we pass NO, which was disabling userInteraction on the entire cell. I tested both scenarios and it seems all good now
