### PR TITLE
[FPMA-1683] Fixed Scrolling Issue on Plus Devices

### DIFF
--- a/Pod/Classes/URBNSwipeableController.m
+++ b/Pod/Classes/URBNSwipeableController.m
@@ -158,7 +158,7 @@ static NSString * const kSwiperControllerCloseAllKey = @"kSwiperControllerCloseA
     /// `automaticallyAdjust`
     self.scrollView.contentInset = UIEdgeInsetsZero;
     self.scrollView.frame = CGRectMake(0, 0, w, h);
-    self.scrollView.contentSize = CGSizeMake(w + [self basementWidth], h);
+    self.scrollView.contentSize = CGSizeMake(w + [self basementWidth], 0);
     self.basementView.frame = CGRectMake(w, 0, [self basementWidth], h);
     self.scrollContentView.frame = CGRectMake(0, 0, w, h);
 }


### PR DESCRIPTION
- When resetting the scrollViews contentSize on a layout update, we now set the height of the contentSize to 0, not the size of the cell. We never scroll vertically in the cells, only horizontally.
- With the contentSize's height set to the height of the cell, there seems to be issues with the table view correctly getting the touch events so it does not scroll
